### PR TITLE
bump viacore-lib from 0.13.22. to 0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "express": "^4.13.3",
     "liftoff": "^2.2.0",
     "viacoind-rpc": "^0.7.1",
-    "viacore-lib": "^0.13.22",
+    "viacore-lib": "^0.14.1",
     "lru-cache": "^4.0.1",
     "mkdirp": "0.5.0",
     "path-is-absolute": "^1.0.0",


### PR DESCRIPTION
There is no 0.13.22 release for `viacore-lib`, 0.14.1 seems to work just fine.